### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol (MCP) server that exposes AI-powered investor agent simulations through the MCP protocol, augmented with Octagon Private Markets data.
 
+<a href="https://glama.ai/mcp/servers/@OctopusAI/investor-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@OctopusAI/investor-mcp/badge" alt="Investor Persona Server MCP server" />
+</a>
+
 ## Features
 
 ### Individual Investor Personas


### PR DESCRIPTION
This PR adds a badge for the [Investor Persona MCP Server](https://glama.ai/mcp/servers/@OctopusAI/investor-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@OctopusAI/investor-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@OctopusAI/investor-mcp/badge" alt="Investor Persona Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.